### PR TITLE
feat: add configurable timeout and default constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ _Integration to connect Home Assistant with n8n workflows through conversation a
 - 📡 Send conversation context and exposed entities to n8n webhooks
 - 🏠 Seamless integration with Home Assistant's voice assistant system
 - 🔧 Configurable webhook URLs and output fields
+- ⏱️ Configurable timeout for handling long-running workflows (1-300 seconds)
 
 ## Installation
 
@@ -49,6 +50,7 @@ _Integration to connect Home Assistant with n8n workflows through conversation a
    - **Name**: A friendly name for your n8n agent
    - **Webhook URL**: The URL of your n8n webhook endpoint (remember to activate the workflow in n8n and to use the production webhook URL)
    - **Output Field**: The field name in the n8n response containing the reply (default: "output")
+   - **Timeout**: The timeout in seconds for waiting for a response from n8n (default: 30 seconds, range: 1-300 seconds)
 
 ### n8n Workflow Setup
 

--- a/custom_components/n8n_conversation/config_flow.py
+++ b/custom_components/n8n_conversation/config_flow.py
@@ -18,8 +18,12 @@ from homeassistant.core import callback
 from .const import (
     CONF_NAME,
     CONF_OUTPUT_FIELD,
+    CONF_TIMEOUT,
     CONF_WEBHOOK_URL,
+    DEFAULT_NAME,
     DEFAULT_OUTPUT_FIELD,
+    DEFAULT_TIMEOUT,
+    DEFAULT_WEBHOOK_URL,
     DOMAIN,
 )
 
@@ -35,11 +39,17 @@ def _get_schema(options: dict[str, Any] | None = None) -> vol.Schema:
         {
             vol.Required(
                 CONF_NAME,
-                description={"suggested_value": options.get(CONF_NAME, "n8n")},
+                description={"suggested_value": options.get(CONF_NAME, DEFAULT_NAME)},
+                default=DEFAULT_NAME,
             ): str,
             vol.Required(
                 CONF_WEBHOOK_URL,
-                description={"suggested_value": options.get(CONF_WEBHOOK_URL, "")},
+                description={
+                    "suggested_value": options.get(
+                        CONF_WEBHOOK_URL, DEFAULT_WEBHOOK_URL
+                    )
+                },
+                default=DEFAULT_WEBHOOK_URL,
             ): str,
             vol.Required(
                 CONF_OUTPUT_FIELD,
@@ -48,7 +58,15 @@ def _get_schema(options: dict[str, Any] | None = None) -> vol.Schema:
                         CONF_OUTPUT_FIELD, DEFAULT_OUTPUT_FIELD
                     )
                 },
+                default=DEFAULT_OUTPUT_FIELD,
             ): str,
+            vol.Optional(
+                CONF_TIMEOUT,
+                description={
+                    "suggested_value": options.get(CONF_TIMEOUT, DEFAULT_TIMEOUT)
+                },
+                default=DEFAULT_TIMEOUT,
+            ): vol.All(vol.Coerce(int), vol.Range(min=1, max=300)),
         }
     )
 

--- a/custom_components/n8n_conversation/const.py
+++ b/custom_components/n8n_conversation/const.py
@@ -5,5 +5,9 @@ DOMAIN = "n8n_conversation"
 CONF_NAME = "name"
 CONF_WEBHOOK_URL = "webhook_url"
 CONF_OUTPUT_FIELD = "output_field"
+CONF_TIMEOUT = "timeout"
 
+DEFAULT_NAME = "n8n"
+DEFAULT_WEBHOOK_URL = ""
 DEFAULT_OUTPUT_FIELD = "output"
+DEFAULT_TIMEOUT = 30

--- a/custom_components/n8n_conversation/conversation.py
+++ b/custom_components/n8n_conversation/conversation.py
@@ -19,7 +19,13 @@ from homeassistant.helpers import (
 )
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import CONF_OUTPUT_FIELD, CONF_WEBHOOK_URL, DOMAIN
+from .const import (
+    CONF_OUTPUT_FIELD,
+    CONF_TIMEOUT,
+    CONF_WEBHOOK_URL,
+    DEFAULT_TIMEOUT,
+    DOMAIN,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -116,9 +122,10 @@ class N8nConversationEntity(
             ),
         }
 
+        timeout = self._config_entry.options.get(CONF_TIMEOUT, DEFAULT_TIMEOUT)
         async with (
             aiohttp.ClientSession() as session,
-            session.post(self._webhook_url, json=payload, timeout=10) as response,
+            session.post(self._webhook_url, json=payload, timeout=timeout) as response,
         ):
             if response.status != 200:
                 raise HomeAssistantError(

--- a/custom_components/n8n_conversation/translations/en.json
+++ b/custom_components/n8n_conversation/translations/en.json
@@ -5,7 +5,8 @@
                 "data": {
                     "name": "Name",
                     "webhook_url": "Webhook URL",
-                    "output_field": "Output Field"
+                    "output_field": "Output Field",
+                    "timeout": "Timeout (seconds)"
                 }
             }
         },


### PR DESCRIPTION
- Add configurable timeout (1-300 seconds) with default of 30 seconds
- Add DEFAULT_NAME constant for default agent name
- Add DEFAULT_WEBHOOK_URL constant for default webhook URL
- Add CONF_TIMEOUT and DEFAULT_TIMEOUT constants
- Update config flow to use constants instead of hardcoded values
- Update translations for timeout field
- Update conversation.py to use configurable timeout

Closes #3